### PR TITLE
[Refactor] Перевод кнопок на RegularText

### DIFF
--- a/src/services/helpers/get-optional-prop.ts
+++ b/src/services/helpers/get-optional-prop.ts
@@ -1,0 +1,3 @@
+const getOptionalProp = (prop: string, value: string | null | undefined) : string => (value ? `${prop}: ${value}` : '');
+
+export default getOptionalProp;

--- a/src/services/helpers/index.ts
+++ b/src/services/helpers/index.ts
@@ -6,6 +6,7 @@ import getAvatarBorderProp from './get-avatar-border-prop';
 import setColor from './set-color';
 import testImageUrl from './test-image-url';
 import getLinesClamp from './get-lines-clamp';
+import getOptionalProp from './get-optional-prop';
 
 export {
   makeErrorMessage,
@@ -16,4 +17,5 @@ export {
   setColor,
   testImageUrl,
   getLinesClamp,
+  getOptionalProp,
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -67,7 +67,6 @@ import {
   clearTag,
   setArtistProfile,
   clearPage,
-  setTooltipVisibility,
 } from './viewSlice';
 
 import {
@@ -137,6 +136,8 @@ import {
   onLogout,
   setTheme,
   setLanguage,
+  openMenu,
+  closeMenu,
 } from './systemSlice';
 
 export {
@@ -256,5 +257,6 @@ export {
   setImage,
   setComment,
   resetComment,
-  setTooltipVisibility,
+  openMenu,
+  closeMenu,
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,6 +26,7 @@ import {
   setEmailProfile,
   setBioProfile,
   setImageProfile,
+  setNicknameProfile,
 } from './profileFormSubSlice';
 
 import {
@@ -163,6 +164,7 @@ export {
   changePasswordRegister,
   resetFormRegister,
   setUsernameProfile,
+  setNicknameProfile,
   setEmailProfile,
   setBioProfile,
   setImageProfile,

--- a/src/store/profileFormSubSlice.ts
+++ b/src/store/profileFormSubSlice.ts
@@ -3,6 +3,7 @@ import { TUser } from '../types/types';
 
 type TProfileFormState = {
   username: string | null;
+  nickname: string | null;
   email: string | null;
   bio: string | null;
   image: string | null;
@@ -11,6 +12,7 @@ type TProfileFormState = {
 
 const initialState: TProfileFormState = {
   username: null,
+  nickname: null,
   email: null,
   bio: null,
   image: null,
@@ -23,6 +25,9 @@ const profileSubSlice = createSlice({
   reducers: {
     setUsernameProfile: (state: TProfileFormState, action: PayloadAction<string>) => ({
       ...state, username: action.payload,
+    }),
+    setNicknameProfile: (state: TProfileFormState, action: PayloadAction<string>) => ({
+      ...state, nickname: action.payload,
     }),
     setEmailProfile: (state: TProfileFormState, action: PayloadAction<string>) => ({
       ...state, email: action.payload,
@@ -51,6 +56,7 @@ const profileSubSlice = createSlice({
 const profileReducer = profileSubSlice.reducer;
 export const {
   setUsernameProfile,
+  setNicknameProfile,
   setEmailProfile,
   setBioProfile,
   setImageProfile,

--- a/src/store/systemSlice.ts
+++ b/src/store/systemSlice.ts
@@ -7,6 +7,7 @@ type TSystemState = {
   appName: string;
   currentTheme: string,
   currentLang: string,
+  isMenuOpen: boolean,
 };
 
 const initialState: TSystemState = {
@@ -14,6 +15,7 @@ const initialState: TSystemState = {
   appName: 'Real World',
   currentTheme: defaultTheme,
   currentLang: defaultLang,
+  isMenuOpen: false,
 };
 
 const systemSlice = createSlice({
@@ -28,6 +30,12 @@ const systemSlice = createSlice({
     setLanguage: (state: TSystemState, action: PayloadAction<string>) => ({
       ...state, currentLang: action.payload,
     }),
+    openMenu: (state: TSystemState) => ({
+      ...state, isMenuOpen: true,
+    }),
+    closeMenu: (state: TSystemState) => ({
+      ...state, isMenuOpen: false,
+    }),
   },
 });
 
@@ -37,5 +45,7 @@ export const {
   onLogout,
   setTheme,
   setLanguage,
+  openMenu,
+  closeMenu,
 } = systemSlice.actions;
 export default systemReducer;

--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -6,6 +6,7 @@ type TUserState = {
   email: string | null,
   bio?: string | null,
   image?: string | null,
+  nickname?: string | null,
 };
 
 const initialState: TUserState = {
@@ -13,6 +14,7 @@ const initialState: TUserState = {
   email: null,
   bio: null,
   image: null,
+  nickname: null,
 };
 
 const userSlice = createSlice({

--- a/src/store/viewSlice.ts
+++ b/src/store/viewSlice.ts
@@ -18,7 +18,6 @@ type TViewState = {
   profile: TProfile | null;
   feedType: FeedTypes;
   articlesType:UserArticlesTypes;
-  isTooltipShown: boolean;
 };
 
 const initialState: TViewState = {
@@ -35,7 +34,6 @@ const initialState: TViewState = {
   profile: null,
   feedType: FeedTypes.public,
   articlesType: UserArticlesTypes.my,
-  isTooltipShown: false,
 };
 
 const viewSlice = createSlice({
@@ -114,9 +112,6 @@ const viewSlice = createSlice({
     setArtistProfile: (state: TViewState, action: PayloadAction<UserArticlesTypes>) => ({
       ...state, articlesType: action.payload,
     }),
-    setTooltipVisibility: (state: TViewState, action: PayloadAction<boolean>) => ({
-      ...state, isTooltipShown: action.payload,
-    }),
   },
 });
 
@@ -145,7 +140,6 @@ export const {
   clearTag,
   setFeedType,
   setArtistProfile,
-  setTooltipVisibility,
 } = viewSlice.actions;
 const viewReducer = viewSlice.reducer;
 export default viewReducer;

--- a/src/types/styles.types.ts
+++ b/src/types/styles.types.ts
@@ -125,6 +125,7 @@ export type TTextProps = {
   paddingCSS?: string;
   clampLines?: boolean;
   heightLimit?: number;
+  align?: string;
 };
 
 export type TFontSizeTypes = 'small' | 'medium' | 'large';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ export type TUser = {
   username: string;
   bio?: string;
   image?:string;
+  nickname?: string;
 };
 
 // Исправлено и переименовано по модели данных сервера
@@ -12,6 +13,7 @@ export type TProfile = {
   username: string;
   email: string;
   bio?: string;
+  nickname?: string;
 };
 
 export type TTags = Array<string>;

--- a/src/ui-lib/buttons.tsx
+++ b/src/ui-lib/buttons.tsx
@@ -66,6 +66,30 @@ const BasicInvertedButton = styled.button<TBasicButtonProps>`
     }
 `;
 
+const MenuButton = styled.button<TBasicButtonProps>`
+  padding: 8px 16px;
+  border-radius: 4px;
+  border-width: 0;
+  width: 172px;
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: center;
+  color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].default, button[colorScheme].disabled)};
+  background-color: ${({ colorScheme, theme: { button } }) => button[colorScheme].font};
+
+  &:hover {
+    color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].hover, button[colorScheme].disabled)};
+    }
+  &:active {
+    color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].active, button[colorScheme].disabled)};
+    }
+  &:focus {
+    color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].active, button[colorScheme].disabled)};
+    }
+`;
+
 export const EditPostButton : FC<TButtonProps> = ({ onClick, disabled = false }) => {
   const theme = useTheme();
   return (
@@ -143,7 +167,7 @@ export const OpenMenuButton: FC<TAvatarButtonProps> = ({
     },
   } = useMouseEvents({});
   return (
-    <BasicInvertedButton
+    <MenuButton
       colorScheme='blue'
       disabled={disabled}
       onClick={onClick}
@@ -159,10 +183,10 @@ export const OpenMenuButton: FC<TAvatarButtonProps> = ({
         image={image}
         distance={iconDistance}
         color={theme.button.blue[setColor(isHovered, isFocused, isActive, !!disabled)]} />
-      <RegularText size='large' weight={500}>
+      <RegularText size='large' weight={500} clampLines heightLimit={40} align='left'>
         {name}
       </RegularText>
-    </BasicInvertedButton>
+    </MenuButton>
   );
 };
 

--- a/src/ui-lib/buttons.tsx
+++ b/src/ui-lib/buttons.tsx
@@ -11,6 +11,7 @@ import {
 } from './icons';
 import { getColor, setColor } from '../services/helpers';
 import useMouseEvents from '../services/hooks/use-mouse-events';
+import { RegularText } from './text-elements';
 
 export const iconDistance = 8;
 
@@ -28,10 +29,6 @@ const BasicNormalButton = styled.button<TBasicButtonProps>`
   flex-flow: row nowrap;
   justify-content: flex-start;
   align-items: center;
-  font-family: ${({ theme: { buttonText: { family } } }) => family};
-  font-size: ${({ theme: { buttonText: { size } } }) => size} px;
-  font-weight: ${({ theme: { buttonText: { weight } } }) => weight};
-  line-height: ${({ theme: { buttonText: { height } } }) => height} px;
   background-color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].default, button[colorScheme].disabled)};
   color: ${({ colorScheme, theme: { button } }) => button[colorScheme].font};
 
@@ -55,10 +52,6 @@ const BasicInvertedButton = styled.button<TBasicButtonProps>`
   flex-flow: row nowrap;
   justify-content: flex-start;
   align-items: center;
-  font-family: ${({ theme: { buttonText: { family } } }) => family};
-  font-size: ${({ theme: { buttonText: { size } } }) => size} px;
-  font-weight: ${({ theme: { buttonText: { weight } } }) => weight};
-  line-height: ${({ theme: { buttonText: { height } } }) => height} px;
   color: ${({ colorScheme, theme: { button }, disabled }) => getColor(disabled, button[colorScheme].default, button[colorScheme].disabled)};
   background-color: ${({ colorScheme, theme: { button } }) => button[colorScheme].font};
 
@@ -83,7 +76,9 @@ export const EditPostButton : FC<TButtonProps> = ({ onClick, disabled = false })
       <EditIcon
         color={theme.button.blue.font}
         distance={iconDistance} />
-      <FormattedMessage id='editArticle' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='editArticle' />
+      </RegularText>
     </BasicNormalButton>
   );
 };
@@ -119,7 +114,9 @@ export const DeletePostButton : FC<TButtonProps> = ({ onClick, disabled = false 
       <DeleteIcon
         color={theme.button.red[setColor(isHovered, isFocused, isActive, !!disabled)]}
         distance={iconDistance} />
-      <FormattedMessage id='deleteArticle' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='deleteArticle' />
+      </RegularText>
     </BasicInvertedButton>
   );
 };
@@ -162,7 +159,9 @@ export const OpenMenuButton: FC<TAvatarButtonProps> = ({
         image={image}
         distance={iconDistance}
         color={theme.button.blue[setColor(isHovered, isFocused, isActive, !!disabled)]} />
-      {name}
+      <RegularText size='large' weight={500}>
+        {name}
+      </RegularText>
     </BasicInvertedButton>
   );
 };
@@ -175,7 +174,9 @@ export const SavePostButton : FC<TButtonProps> = ({ onClick, disabled = false })
 
 export const ConfirmDeleteButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='red' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='deleteArticle' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='deleteArticle' />
+    </RegularText>
   </BasicNormalButton>
 );
 
@@ -184,7 +185,9 @@ export const FollowButton: FC<TButtonProps> = ({ onClick, disabled = false }) =>
   return (
     <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
       <PlusIcon color={theme.button.blue.font} distance={iconDistance} />
-      <FormattedMessage id='subscribe' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='subscribe' />
+      </RegularText>
     </BasicNormalButton>
   );
 };
@@ -194,37 +197,49 @@ export const UnfollowButton : FC<TButtonProps> = ({ onClick, disabled = false })
   return (
     <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
       <MinusIcon color={theme.button.blue.font} distance={iconDistance} />
-      <FormattedMessage id='unsubscribe' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='unsubscribe' />
+      </RegularText>
     </BasicNormalButton>
   );
 };
 
 export const PostCommentButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='sendComment' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='sendComment' />
+    </RegularText>
   </BasicNormalButton>
 );
 
 export const RegisterButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='register' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='register' />
+    </RegularText>
   </BasicNormalButton>
 );
 
 export const LoginButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='userLogin' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='userLogin' />
+    </RegularText>
   </BasicNormalButton>
 );
 
 export const UpdateProfileButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='refreshUser' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='refreshUser' />
+    </RegularText>
   </BasicNormalButton>
 );
 export const PublishPostButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
   <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
-    <FormattedMessage id='publishArticle' />
+    <RegularText size='large' weight={500}>
+      <FormattedMessage id='publishArticle' />
+    </RegularText>
   </BasicNormalButton>
 );
 
@@ -238,7 +253,9 @@ export const MenuSettingsButton : FC<TButtonProps> = ({ onClick, disabled = fals
       <AsterixIcon
         color={theme.button.menu.font}
         distance={iconDistance} />
-      <FormattedMessage id='settings' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='settings' />
+      </RegularText>
     </BasicNormalButton>
   );
 };
@@ -253,7 +270,9 @@ export const MenuNewPostButton : FC<TButtonProps> = ({ onClick, disabled = false
       <EditIcon
         color={theme.button.menu.font}
         distance={iconDistance} />
-      <FormattedMessage id='newArticle' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='newArticle' />
+      </RegularText>
     </BasicNormalButton>
   );
 };
@@ -268,7 +287,9 @@ export const MenuLogoutButton : FC<TButtonProps> = ({ onClick, disabled = false 
       <LogoutIcon
         color={theme.button.menu.font}
         distance={iconDistance} />
-      <FormattedMessage id='exitProfile' />
+      <RegularText size='large' weight={500}>
+        <FormattedMessage id='exitProfile' />
+      </RegularText>
     </BasicNormalButton>
   );
 };

--- a/src/ui-lib/text-elements.tsx
+++ b/src/ui-lib/text-elements.tsx
@@ -135,8 +135,8 @@ export const HeaderFiveText = styled.h5<THeaderTextProps>`
 `;
 
 export const RegularText = styled.p<TTextProps>`
-   font-family: ${({ sansSerif }) => (sansSerif ? 'Alegreya Sans' : 'Alegreya')};
-   font-size: ${({ size }) => defaultFontSizes[size].size}px;
+  font-family: ${({ sansSerif }) => (sansSerif ? 'Alegreya Sans' : 'Alegreya')};
+  font-size: ${({ size }) => defaultFontSizes[size].size}px;
   font-weight: ${({ weight }) => (weight || 400)};
   line-height: ${({ size }) => defaultFontSizes[size].height}px;
   color: ${({ color }) => (color || 'inherit')};

--- a/src/ui-lib/text-elements.tsx
+++ b/src/ui-lib/text-elements.tsx
@@ -17,7 +17,7 @@ import {
 } from '../constants/fontsconfigs';
 
 import { tabletBreakpoint } from '../constants';
-import { getLinesClamp } from '../services/helpers';
+import { getLinesClamp, getOptionalProp } from '../services/helpers';
 
 export const HeaderOneText = styled.h1<THeaderTextProps>`
    font-family: ${defaultH1.family};
@@ -142,6 +142,11 @@ export const RegularText = styled.p<TTextProps>`
   color: ${({ color }) => (color || 'inherit')};
   text-overflow: ellipsis;
   margin-bottom: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  ${({ align }) => getOptionalProp('text-align', align)};
   ${({
     clampLines,
     heightLimit,

--- a/src/widgets/header-menu-widget.tsx
+++ b/src/widgets/header-menu-widget.tsx
@@ -1,0 +1,59 @@
+import React, { FC, MouseEventHandler } from 'react';
+import styled from 'styled-components';
+
+import {
+  OpenMenuButton, MenuSettingsButton, MenuNewPostButton, MenuLogoutButton,
+} from '../ui-lib';
+import { useDispatch, useSelector } from '../services/hooks';
+import { closeMenu, onLogout } from '../store';
+
+const HeaderMenuWrapper = styled.nav`
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 0;
+  gap: 1px;
+  width: 173px;  
+  background: ${({ theme: { bgPrimary } }) => bgPrimary};
+
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08), 0 0 4px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+`;
+
+const HeaderMenuWidget : FC = () => {
+  const dispatch = useDispatch();
+  const { nickname, username, image } = useSelector((store) => store.profile);
+  const onCloseClick : MouseEventHandler<HTMLButtonElement> = () => dispatch(closeMenu());
+  const onUpdateProfileClick : MouseEventHandler<HTMLButtonElement> = () => alert('Здесь будет редирект на редактирование профиля!');
+  const onNewPostClick : MouseEventHandler<HTMLButtonElement> = () => alert('Здесь будет редирект на создание новой статьи!');
+  const onLogoutClick : MouseEventHandler<HTMLButtonElement> = () => dispatch(onLogout());
+  return (
+    <HeaderMenuWrapper>
+      <OpenMenuButton onClick={onCloseClick} name={(nickname ?? username) || ''} image={image || ''} />
+      <MenuNewPostButton onClick={onNewPostClick} />
+      <MenuSettingsButton onClick={onUpdateProfileClick} />
+      <MenuLogoutButton onClick={onLogoutClick} />
+    </HeaderMenuWrapper>
+  );
+};
+
+export default HeaderMenuWidget;
+
+// Сниппет добавления меню в шапку
+/*
+  const dispatch = useDispatch();
+  const { isMenuOpen } = useSelector((state) => state.system);
+  const { nickname, username, image } = useSelector((store) => store.profile);
+
+  const onOpenMenuClick : MouseEventHandler<HTMLButtonElement> = () => dispatch(openMenu());
+
+{ isMenuOpen ? (
+              <HeaderMenuWidget />
+            ) : (
+              <OpenMenuButton
+                onClick={onOpenMenuClick}
+                name={(nickname ?? username) || ''}
+                image={image || ''} />
+            )}
+ */

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -4,6 +4,7 @@ import PopularTags from './PopularTags';
 import Likes from './likes';
 import ProfileWidget from './profile-widget';
 import AuthorHeadingMiniWidget from './author-heading-widget';
+import HeaderMenuWidget from './header-menu-widget';
 
 export {
   Author,
@@ -12,4 +13,5 @@ export {
   Likes,
   ProfileWidget,
   AuthorHeadingMiniWidget,
+  HeaderMenuWidget,
 };


### PR DESCRIPTION
Типографика убрана из `styled.button`, применён `RegularText`.
Откорректировано хранилище для меню и отображаемого имени.
Меню в шапке готово, сниппет вставки в шапку в комментарии в конце файла header-menu-widget.tsx