### PR TITLE
[Fix] Потерянные формы ввода

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -28,6 +28,10 @@ import {
   setBioProfile,
   setImageProfile,
   setNicknameProfile,
+  setFormProfile,
+  setPasswordProfile,
+  resetFormProfile,
+
 } from './profileFormSubSlice';
 
 import {
@@ -58,7 +62,6 @@ import {
   clearSelectedTags,
   setViewCommentsFeed,
   clearViewCommentsFeed,
-  setViewCommentFeed,
   selectViewComment,
   clearViewComment,
   setPage,
@@ -178,6 +181,9 @@ export {
   setEmailProfile,
   setBioProfile,
   setImageProfile,
+  setFormProfile,
+  setPasswordProfile,
+  resetFormProfile,
   setAllArticles,
   setAllArticlesCount,
   setAllTags,
@@ -199,7 +205,6 @@ export {
   clearSelectedTags,
   setViewCommentsFeed,
   clearViewCommentsFeed,
-  setViewCommentFeed,
   selectViewComment,
   clearViewComment,
   setViewProfile,

--- a/src/store/viewSlice.ts
+++ b/src/store/viewSlice.ts
@@ -11,7 +11,7 @@ type TViewState = {
   tagsList: TTags | null;
   selectedTags: TTags | null;
   tag: string | null,
-  commentsFeed: TComments;
+  commentsFeed: TComments | null;
   comment: TComment | null;
   page: number;
   perPage: number;
@@ -28,7 +28,7 @@ const initialState: TViewState = {
   tagsList: null,
   selectedTags: null,
   tag: null,
-  commentsFeed: [],
+  commentsFeed: null,
   comment: null,
   page: 1,
   perPage: 10,
@@ -81,12 +81,11 @@ const viewSlice = createSlice({
     clearTag: (state: TViewState) => ({
       ...state, tag: null,
     }),
-    setViewCommentsFeed: (state: TViewState, action: PayloadAction<TComments>) => ({
-      ...state, commentsFeed: action.payload,
-    }),
-    setViewCommentFeed: (state: TViewState, action: PayloadAction<TComment>) => ({
-      ...state, commentsFeed: [...state.commentsFeed, action.payload],
-    }),
+    setViewCommentsFeed: (state: TViewState, action: PayloadAction<TComments>) => {
+      const { commentsFeed } = state;
+      const newCommentsFeed = commentsFeed ? [...commentsFeed, ...action.payload] : action.payload;
+      return { ...state, commentsFeed: newCommentsFeed };
+    },
     clearViewCommentsFeed: (state: TViewState) => ({
       ...state, commentsFeed: [],
     }),
@@ -135,7 +134,6 @@ export const {
   setSelectedTags,
   clearSelectedTags,
   setViewCommentsFeed,
-  setViewCommentFeed,
   clearViewCommentsFeed,
   selectViewComment,
   clearViewComment,

--- a/src/thunks/create-comment-thunk.ts
+++ b/src/thunks/create-comment-thunk.ts
@@ -6,7 +6,7 @@ import {
   commentPostRequested,
   commentPostSucceeded,
   commentPostFailed,
-  setViewCommentFeed,
+  setViewCommentsFeed,
   resetComment,
 } from '../store';
 import { TAPIError } from '../services/api.types';
@@ -16,15 +16,17 @@ const createCommentThunk: AppThunk = (slug: string) => async (
   dispatch: AppDispatch,
   getState: () => RootState,
 ) => {
-  const comment = getState().forms.comment.comment ?? '';
+  const newComment = getState().forms.comment.comment ?? '';
   try {
-    dispatch(commentPostRequested());
-    const { data } = await postComment(slug, comment);
-    batch(() => {
-      dispatch(setViewCommentFeed(data.comment));
-      dispatch(resetComment());
-      dispatch(commentPostSucceeded());
-    });
+    if (newComment) {
+      dispatch(commentPostRequested());
+      const { data: { comment } } = await postComment(slug, newComment);
+      batch(() => {
+        dispatch(setViewCommentsFeed([comment]));
+        dispatch(resetComment());
+        dispatch(commentPostSucceeded());
+      });
+    }
   } catch (error) {
     dispatch(commentPostFailed(makeErrorObject(error as AxiosError<TAPIError>)));
   }

--- a/src/types/styles.types.ts
+++ b/src/types/styles.types.ts
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import React, { MouseEventHandler } from 'react';
 
 export type TColorSet = {
   default: string;
@@ -152,4 +152,16 @@ export type TDefaultFontSizes = {
 
 export type TDividerProps = {
   distance: number;
+};
+
+export type TInputFieldType = 'text' | 'email' | 'password' | 'url';
+
+export type TFieldInput = {
+  value: string;
+  placeholder?: string;
+  error?: boolean;
+  disabled?: boolean;
+  errorText?: string;
+  onBlur?(e?: React.FocusEvent<HTMLInputElement>): void;
+  onChange(e: React.ChangeEvent<HTMLInputElement>): void;
 };

--- a/src/types/widgets.types.ts
+++ b/src/types/widgets.types.ts
@@ -39,10 +39,8 @@ export type TAuthorProps = {
   imageSrc?: string,
 };
 
-export type TCommentInputProps = TAuthorProps & {
-  onChangeArea(e: React.ChangeEvent<HTMLTextAreaElement>): void;
-  onButtonClick: React.MouseEventHandler<HTMLButtonElement>;
-  disabledButton?: boolean | undefined;
+export type TCommentInputProps = {
+  slug: string;
 };
 
 interface IGenericVoidHandler {

--- a/src/ui-lib/buttons.tsx
+++ b/src/ui-lib/buttons.tsx
@@ -7,7 +7,15 @@ import {
 } from '../types/styles.types';
 
 import {
-  EditIcon, AvatarIcon, DeleteIcon, PlusIcon, MinusIcon, AsterixIcon, LogoutIcon, HomeIcon, LoginIcon,
+  EditIcon,
+  AvatarIcon,
+  DeleteIcon,
+  PlusIcon,
+  MinusIcon,
+  AsterixIcon,
+  LogoutIcon,
+  HomeIcon,
+  LoginIcon,
 } from './icons';
 import { getColor, setColor } from '../services/helpers';
 import useMouseEvents from '../services/hooks/use-mouse-events';
@@ -190,8 +198,8 @@ export const OpenMenuButton: FC<TAvatarButtonProps> = ({
   );
 };
 
-export const SavePostButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const SavePostButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <FormattedMessage id='saveArticle' />
   </BasicNormalButton>
 );
@@ -236,39 +244,39 @@ export const PostCommentButton : FC<TButtonProps> = ({ onClick, disabled = false
   </BasicNormalButton>
 );
 
-export const RegisterButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const RegisterButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <RegularText size='large' weight={500}>
       <FormattedMessage id='register' />
     </RegularText>
   </BasicNormalButton>
 );
 
-export const LoginButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const LoginButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <RegularText size='large' weight={500}>
       <FormattedMessage id='userLogin' />
     </RegularText>
   </BasicNormalButton>
 );
 
-export const UpdateProfileButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const UpdateProfileButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <RegularText size='large' weight={500}>
       <FormattedMessage id='refreshUser' />
     </RegularText>
   </BasicNormalButton>
 );
-export const PublishPostButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const PublishPostButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <RegularText size='large' weight={500}>
       <FormattedMessage id='publishArticle' />
     </RegularText>
   </BasicNormalButton>
 );
 
-export const PublishCommentButton : FC<TButtonProps> = ({ onClick, disabled = false }) => (
-  <BasicNormalButton colorScheme='blue' disabled={disabled} onClick={onClick}>
+export const PublishCommentButton : FC<Omit<TButtonProps, 'onClick'>> = ({ disabled = false }) => (
+  <BasicNormalButton type='submit' colorScheme='blue' disabled={disabled}>
     <FormattedMessage id='publishComment' />
   </BasicNormalButton>
 );
@@ -356,4 +364,4 @@ export const HeaderLoginButton : FC<TButtonProps> = ({ onClick, disabled = false
       </RegularText>
     </BasicNormalButton>
   );
-}
+};

--- a/src/ui-lib/index.ts
+++ b/src/ui-lib/index.ts
@@ -43,13 +43,19 @@ import {
   FieldLogin,
   FieldEmail,
   FieldPassword,
-  FieldNewPassword,
   FieldNameArticle,
   FieldDescriptionArticle,
   FieldTegs,
+  FieldNick,
+  FieldProfileImage,
 }
   from './textFields/inputFields';
-
+import {
+  FieldTextComment,
+  FieldAboutArticle,
+  FieldAboutUser,
+  FieldTextArticle,
+} from './textFields/textAreaFields';
 import {
   HeaderOneText,
   HeaderTwoText,
@@ -101,10 +107,15 @@ export {
   FieldLogin,
   FieldEmail,
   FieldPassword,
-  FieldNewPassword,
+  FieldNick,
   FieldNameArticle,
   FieldDescriptionArticle,
   FieldTegs,
+  FieldProfileImage,
+  FieldTextArticle,
+  FieldAboutUser,
+  FieldAboutArticle,
+  FieldTextComment,
   HeaderOneText,
   HeaderTwoText,
   HeaderThreeText,

--- a/src/ui-lib/textFields/inputFieldConfig.tsx
+++ b/src/ui-lib/textFields/inputFieldConfig.tsx
@@ -1,15 +1,23 @@
 import styled from 'styled-components';
-import React, { useState, FC } from 'react';
+import React, {
+  FC, ChangeEventHandler, MouseEventHandler, FocusEventHandler,
+} from 'react';
 import { TextFieldStyle, LabelStyle, ErorText } from './textFields-styles';
+import { TInputFieldType } from '../../types/styles.types';
 
 const InputStyle = styled.input<{ error: boolean | undefined }>`
      ${TextFieldStyle}
  `;
+
 const ContainerInput = styled.div`
      width: 100%;
      margin: 0;
      padding: 0;
-     position: relative;
+    position: relative;
+     display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
      @media screen and (max-width:768px) {
         font-size: 16px;
      }
@@ -19,27 +27,29 @@ const ContainerIcon = styled.div`
      position: absolute;
      top:32px;
      right:16px;
+
  `;
-type TInputInterface = {
-  type: 'text' | 'email' | 'password' | 'url';
-  placeholder?: string;
-  value?: string;
-  name?: string;
+
+interface IInputInterface {
+  type: TInputFieldType;
+  placeholder: string;
+  value: string;
+  name: string;
   error?: boolean;
   icon?: React.ReactNode;
   errorText?: string;
   disabled?: boolean;
   labelText?: string;
-  onChange(e: React.ChangeEvent<HTMLInputElement>): void;
-  onIconClick?(e: React.MouseEvent<HTMLDivElement>): void;
-  onBlur?(e?: React.FocusEvent<HTMLInputElement>): void;
-  onFocus?(e?: React.FocusEvent<HTMLInputElement>): void;
-};
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onIconClick?: MouseEventHandler;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onFocus?: FocusEventHandler<HTMLInputElement>;
+}
 
-export const InputField = ({
-  type, placeholder, value, name, error, icon = null, errorText, onChange, onIconClick, onBlur, onFocus,
-  disabled, labelText,
-}: TInputInterface) => (
+export const InputField :FC<IInputInterface> = ({
+  type, placeholder, value, name, error = false, icon = null, errorText = '', onChange, onIconClick, onBlur, onFocus,
+  disabled = false, labelText = '',
+}: IInputInterface) => (
   <ContainerInput>
     <LabelStyle>
       {labelText}

--- a/src/ui-lib/textFields/inputFields.tsx
+++ b/src/ui-lib/textFields/inputFields.tsx
@@ -1,30 +1,20 @@
 import React, { FC, useState } from 'react';
-import InputField from './inputFieldConfig';
+import { InputField } from './inputFieldConfig';
 import { PaperClipIcon, EyeIcon, EyeNoIcon } from '../icons';
+import { TFieldInput } from '../../types/styles.types';
 
-type TFieldInput = {
-  name?: string;
-  value: string;
-  error?: boolean;
-  disabled?: boolean;
-  placeholder?: string;
-  errorText?: string;
-  onBlur?(e?: React.FocusEvent<HTMLInputElement>): void;
-  onChange(e: React.ChangeEvent<HTMLInputElement>): void;
-};
 export const FieldUrl: FC<TFieldInput> = ({
   value,
-  name = 'FieldUrl',
   onBlur,
   onChange,
-  placeholder = 'Введите URL',
+  placeholder = '',
   error = false,
   errorText = '',
   disabled = false,
 }) => (
   <InputField
     placeholder={placeholder}
-    name={name}
+    name='FieldURL'
     type='url'
     errorText={errorText}
     error={error}
@@ -39,7 +29,7 @@ export const FieldProfileImage: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (
@@ -59,7 +49,7 @@ export const FieldLogin: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (
@@ -74,11 +64,30 @@ export const FieldLogin: FC<TFieldInput> = ({
     onChange={onChange}
     labelText='Имя пользователя' />
 );
+export const FieldNick: FC<TFieldInput> = ({
+  value,
+  onBlur,
+  onChange,
+  placeholder = '',
+  error,
+  errorText,
+}) => (
+  <InputField
+    placeholder={placeholder}
+    name='FieldNick'
+    type='text'
+    errorText={errorText}
+    error={error}
+    onBlur={onBlur}
+    value={value}
+    onChange={onChange}
+    labelText='Отображаемое имя' />
+);
 export const FieldEmail: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (
@@ -93,13 +102,15 @@ export const FieldEmail: FC<TFieldInput> = ({
     onChange={onChange}
     labelText='Email' />
 );
-export const FieldPassword: FC<TFieldInput> = ({
+export const FieldPassword: FC<TFieldInput & { label?: string, name?: string }> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  name = 'FieldPassword',
   error,
   errorText,
+  label = 'Пароль',
+  placeholder = '',
 }) => {
   const [passwordState,
     setPasswordState] = useState<'password' | 'text'>('password');
@@ -116,59 +127,24 @@ export const FieldPassword: FC<TFieldInput> = ({
   return (
     <InputField
       placeholder={placeholder}
-      name='Password'
+      name={name}
       type={passwordState}
       errorText={errorText}
       error={error}
       onBlur={onBlur}
       value={value}
       onChange={onChange}
-      labelText='Пароль'
+      labelText={label}
       icon={passwordIcon}
+      onIconClick={onIconClick} />
+  );
+};
 
-      onIconClick={onIconClick} />
-  );
-};
-export const FieldNewPassword: FC<TFieldInput> = ({
-  value,
-  onBlur, onChange,
-  placeholder,
-  error,
-  errorText,
-}) => {
-  const [passwordState,
-    setPasswordState] = useState<'password' | 'text'>('password');
-  const [passwordIcon, setPasswordIcon] = useState(<EyeNoIcon color='grey' />);
-  const onIconClick = () => {
-    if (passwordState === 'password') {
-      setPasswordState('text');
-      setPasswordIcon(<EyeIcon color='grey' />);
-    } else {
-      setPasswordState('password');
-      setPasswordIcon(<EyeNoIcon color='grey' />);
-    }
-  };
-  return (
-    <InputField
-      placeholder={placeholder}
-      name='Password'
-      type={passwordState}
-      errorText={errorText}
-      error={error}
-      onBlur={onBlur}
-      value={value}
-      onChange={onChange}
-      labelText='Пароль'
-      icon={passwordIcon}
-     
-      onIconClick={onIconClick} />
-  );
-};
 export const FieldDescriptionArticle: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (
@@ -187,7 +163,7 @@ export const FieldNameArticle: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (
@@ -206,7 +182,7 @@ export const FieldTegs: FC<TFieldInput> = ({
   value,
   onBlur,
   onChange,
-  placeholder,
+  placeholder = '',
   error,
   errorText,
 }) => (

--- a/src/ui-lib/textFields/textAreaFieldConfig.tsx
+++ b/src/ui-lib/textFields/textAreaFieldConfig.tsx
@@ -12,7 +12,7 @@ const TextAreaStyle = styled.textarea<TTextAreaStyleProps>`
   ${TextFieldStyle}
   resize: none;
   min-height: ${({ minHeight }) => minHeight ?? 0}px;
-  ${({ isHasBorder }) => !isHasBorder && css`border 0`};
+  ${({ isHasBorder }) => !isHasBorder && css`border: 0;`};
 `;
 
 const ContainerTextArea = styled.div`
@@ -40,7 +40,7 @@ type TTextAreaInterface = {
   isHasBorder?: boolean;
 };
 
-export const TextAreaField = ({
+const TextAreaField = ({
   placeholder, value, name, error, errorText, onChange, onBlur, onFocus,
   disabled, labelText, minHeight, isHasBorder,
 }: TTextAreaInterface) => (

--- a/src/ui-lib/textFields/textAreaFields.tsx
+++ b/src/ui-lib/textFields/textAreaFields.tsx
@@ -1,16 +1,15 @@
-import React, { FC } from 'react';
+import React, { ChangeEventHandler, FC, FocusEventHandler } from 'react';
 import TextAreaField from './textAreaFieldConfig';
 
 type TFieldInput = {
-  name?: string;
   minHeight?: number;
   value?: string;
   error?: boolean;
   disabled?: boolean;
   placeholder?: string;
   errorText?: string;
-  onBlur?(e?: React.FocusEvent<HTMLTextAreaElement>): void;
-  onChange(e: React.ChangeEvent<HTMLTextAreaElement>): void;
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>;
+  onChange: ChangeEventHandler<HTMLTextAreaElement>;
   isHasBorder?: boolean;
 };
 
@@ -26,6 +25,21 @@ export const FieldAboutArticle: FC<TFieldInput> = ({
     value={value}
     onChange={onChange}
     labelText='О чем статья'
+    minHeight={minHeight} />
+);
+
+export const FieldAboutUser: FC<TFieldInput> = ({
+  value, onBlur, onChange, placeholder, error, errorText, minHeight,
+}) => (
+  <TextAreaField
+    placeholder={placeholder}
+    name='FieldAboutArticle'
+    errorText={errorText}
+    error={error}
+    onBlur={onBlur}
+    value={value}
+    onChange={onChange}
+    labelText='Расскажите о себе'
     minHeight={minHeight} />
 );
 
@@ -56,6 +70,5 @@ export const FieldTextComment: FC<TFieldInput & { isHasBorder?: boolean }> = ({
     value={value}
     onChange={onChange}
     minHeight={minHeight}
-    isHasBorder={isHasBorder}
-  />
+    isHasBorder={isHasBorder} />
 );

--- a/src/widgets/comment-input.tsx
+++ b/src/widgets/comment-input.tsx
@@ -1,11 +1,15 @@
-import React, { FC } from 'react';
+import React, { FC, FormEventHandler, ChangeEventHandler } from 'react';
 import styled from 'styled-components';
+
+import { createCommentThunk } from '../thunks';
 import { TCommentInputProps } from '../types/widgets.types';
 import { PublishCommentButton } from '../ui-lib/buttons';
 import { FieldTextComment } from '../ui-lib/textFields/textAreaFields';
 import Author from './author';
+import { useDispatch, useSelector } from '../services/hooks';
+import { setComment } from '../store';
 
-const CommentInputContainer = styled.div`
+const CommentInputContainer = styled.form`
   display: flex;
   flex-flow: column nowrap;
   border: 1px solid${({ theme: { dividerColor } }) => dividerColor};
@@ -33,18 +37,35 @@ const CommentButtonWrapper = styled.div`
   }
 `;
 
-const CommentInput: FC<TCommentInputProps> = ({
-  userName, createAt, imageSrc, onButtonClick, disabledButton, onChangeArea,
-}) => (
-  <CommentInputContainer>
-    <FieldTextComment minHeight={112} isHasBorder={false} onChange={onChangeArea} />
-    <CommentInfoWrapper>
-      <Author userName={userName} createAt={createAt} imageSrc={imageSrc} />
-      <CommentButtonWrapper>
-        <PublishCommentButton disabled={disabledButton} onClick={onButtonClick} />
-      </CommentButtonWrapper>
-    </CommentInfoWrapper>
-  </CommentInputContainer>
-);
+const CommentInput: FC<TCommentInputProps> = ({ slug }) => {
+  const dispatch = useDispatch();
+  const { isCommentPosting } = useSelector((state) => state.api);
+  const { comment } = useSelector((state) => state.forms.comment);
+  const { username, nickname, image } = useSelector((state) => state.profile);
+
+  const onChangeComment : ChangeEventHandler<HTMLTextAreaElement> = (evt) => {
+    dispatch(setComment(evt.target.value));
+  };
+
+  const handleCommentSubmit : FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    dispatch(createCommentThunk(slug));
+  };
+
+  if (username) {
+    return (
+      <CommentInputContainer onSubmit={handleCommentSubmit}>
+        <FieldTextComment minHeight={112} isHasBorder={false} onChange={onChangeComment} value={comment || ''} />
+        <CommentInfoWrapper>
+          <Author userName={nickname ?? username} createAt={new Date()} imageSrc={image || ''} />
+          <CommentButtonWrapper>
+            <PublishCommentButton disabled={isCommentPosting} />
+          </CommentButtonWrapper>
+        </CommentInfoWrapper>
+      </CommentInputContainer>
+    );
+  }
+  return null;
+};
 
 export default CommentInput;

--- a/src/widgets/forms/login-form.tsx
+++ b/src/widgets/forms/login-form.tsx
@@ -1,0 +1,67 @@
+import React, {
+  useEffect,
+  FC,
+  ChangeEventHandler,
+  FormEventHandler,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { FormattedMessage } from 'react-intl';
+
+import { useSelector, useDispatch } from '../../services/hooks';
+
+import { changeEmailLogin, changePasswordLogin } from '../../store';
+import { loginUserThunk } from '../../thunks';
+import {
+  ButtonContainer, Form, FormContainer, FormLoginLink, FormTitle, InputFieldset,
+} from './forms-styles';
+import { FieldEmail, FieldPassword, LoginButton } from '../../ui-lib';
+
+const LoginForm: FC = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const { isLoggedIn } = useSelector((state) => state.system);
+  const { email, password } = useSelector((state) => state.forms.login);
+  const { isUserLoggingIn } = useSelector((state) => state.api);
+
+  const changeEmail : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changeEmailLogin(evt.target.value));
+  };
+
+  const changePassword : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changePasswordLogin(evt.target.value));
+  };
+
+  const submitForm : FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    dispatch(loginUserThunk());
+  };
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      navigate('/');
+    }
+  }, [isLoggedIn, navigate]);
+
+  return (
+    <FormContainer>
+      <FormTitle>
+        <FormattedMessage id='userLogin' />
+      </FormTitle>
+      <FormLoginLink to='/register'>
+        <FormattedMessage id='register' />
+      </FormLoginLink>
+      <Form onSubmit={submitForm}>
+        <InputFieldset rowGap={16}>
+          <FieldEmail value={email ?? ''} onChange={changeEmail} />
+          <FieldPassword value={password ?? ''} onChange={changePassword} />
+        </InputFieldset>
+        <ButtonContainer>
+          <LoginButton disabled={isUserLoggingIn} />
+        </ButtonContainer>
+      </Form>
+    </FormContainer>
+  );
+};
+export default LoginForm;

--- a/src/widgets/forms/register-form.tsx
+++ b/src/widgets/forms/register-form.tsx
@@ -1,0 +1,83 @@
+import { useNavigate } from 'react-router-dom';
+import React, {
+  ChangeEventHandler, FC, FormEventHandler, useEffect,
+} from 'react';
+import { useTheme } from 'styled-components';
+import { FormattedMessage } from 'react-intl';
+import { useSelector, useDispatch } from '../../services/hooks';
+import {
+  changeUsernameRegister,
+  changeEmailRegister,
+  changePasswordRegister,
+  resetFormRegister,
+  changeNicknameRegister,
+} from '../../store';
+import { registerThunk } from '../../thunks';
+import {
+  ButtonContainer, Form, FormContainer, FormLoginLink, FormTitle, InputFieldset,
+} from './forms-styles';
+import {
+  FieldEmail, FieldLogin, FieldNick, FieldPassword, RegisterButton,
+} from '../../ui-lib';
+
+const RegisterForm: FC = () => {
+  const {
+    username, email, password, nickname,
+  } = useSelector((state) => state.forms.register);
+  const { isUserRegistering } = useSelector((state) => state.api);
+  const { isLoggedIn } = useSelector((state) => state.system);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const onChangeEmail : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changeEmailRegister(evt.target.value));
+  };
+
+  const onChangePassword : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changePasswordRegister(evt.target.value));
+  };
+
+  const onChangeUsername : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changeUsernameRegister(evt.target.value));
+  };
+
+  const onChangeNickname : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(changeNicknameRegister(evt.target.value));
+  };
+
+  const submitForm : FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    dispatch(registerThunk());
+  };
+
+  useEffect(() => () => {
+    if (isLoggedIn) {
+      navigate('/');
+    }
+    dispatch(resetFormRegister());
+  }, [dispatch, isLoggedIn, navigate]);
+
+  return (
+    <FormContainer>
+      <FormTitle>
+        <FormattedMessage id='register' />
+      </FormTitle>
+      <FormLoginLink to='/login'>
+        <FormattedMessage id='userLogin' />
+      </FormLoginLink>
+      <Form onSubmit={submitForm}>
+        <InputFieldset rowGap={16}>
+          <FieldLogin value={username ?? ''} onChange={onChangeUsername} />
+          <FieldNick value={nickname ?? ''} onChange={onChangeNickname} />
+          <FieldEmail value={email ?? ''} onChange={onChangeEmail} />
+          <FieldPassword value={password ?? ''} onChange={onChangePassword} />
+        </InputFieldset>
+        <ButtonContainer>
+          <RegisterButton disabled={isUserRegistering} />
+        </ButtonContainer>
+      </Form>
+    </FormContainer>
+  );
+};
+
+export default RegisterForm;

--- a/src/widgets/forms/settings-form.tsx
+++ b/src/widgets/forms/settings-form.tsx
@@ -1,0 +1,123 @@
+import React, {
+  ChangeEventHandler, FC, FormEventHandler, useEffect,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from 'styled-components';
+import { FormattedMessage } from 'react-intl';
+import { useDispatch, useSelector } from '../../services/hooks';
+
+import {
+  setUsernameProfile,
+  setEmailProfile,
+  setBioProfile,
+  setImageProfile,
+  setNicknameProfile,
+  setFormProfile,
+  setPasswordProfile,
+} from '../../store';
+
+import { patchCurrentUserThunk } from '../../thunks';
+
+import {
+  ButtonContainer,
+  Form,
+  FormContainer,
+  FormTitle,
+  InputFieldset,
+} from './forms-styles';
+
+import {
+  FieldEmail,
+  FieldLogin,
+  FieldNick,
+  FieldPassword,
+  FieldProfileImage,
+  UpdateProfileButton,
+  FieldAboutUser,
+} from '../../ui-lib';
+
+const SettingsForm: FC = () => {
+  const {
+    bio, email, image, username, password, nickname,
+  } = useSelector((state) => state.forms.profile);
+
+  const profile = useSelector((state) => state.profile);
+
+  const { isSettingsPatching, isSettingsUpdateSucceeded } = useSelector((state) => state.api);
+
+  const dispatch = useDispatch();
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    dispatch(setFormProfile({
+      username: profile.username || '',
+      email: profile.email || '',
+      nickname: profile.nickname || '',
+      bio: profile.bio || '',
+      image: profile.image || ',',
+    }));
+  }, [dispatch, profile]);
+
+  useEffect(() => {
+    if (isSettingsUpdateSucceeded) {
+      navigate('/');
+    }
+  //  return () => { dispatch(settingsResetUpdateSucceeded()); };
+  }, [dispatch, isSettingsUpdateSucceeded, navigate]);
+
+  const submitForm : FormEventHandler<HTMLFormElement> = (evt) => {
+    evt.preventDefault();
+    dispatch(patchCurrentUserThunk());
+  };
+
+  const changeImage : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(setImageProfile(evt.target.value));
+  };
+
+  const changeUsername : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(setUsernameProfile(evt.target.value));
+  };
+
+  const changeBioProfile : ChangeEventHandler<HTMLTextAreaElement> = (evt) => {
+    dispatch(setBioProfile(evt.target.value));
+  };
+
+  const changeEmail : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(setEmailProfile(evt.target.value));
+  };
+  const changeNickname : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(setNicknameProfile(evt.target.value));
+  };
+  const changePassword : ChangeEventHandler<HTMLInputElement> = (evt) => {
+    dispatch(setPasswordProfile(evt.target.value));
+  };
+
+  return (
+    <FormContainer>
+      <FormTitle>
+        <FormattedMessage id='usersettings' />
+      </FormTitle>
+      <Form onSubmit={submitForm}>
+        <InputFieldset rowGap={16}>
+          <FieldProfileImage value={image ?? ''} onChange={changeImage} />
+          <FieldLogin value={username ?? ''} onChange={changeUsername} />
+          <FieldNick value={nickname ?? ''} onChange={changeNickname} />
+          <FieldAboutUser
+            onChange={changeBioProfile}
+            value={bio ?? ''}
+            minHeight={theme.text18.height * 5}
+            name='FieldBio' />
+          <FieldEmail value={email ?? ''} onChange={changeEmail} />
+          <FieldPassword value={password ?? ''} onChange={changePassword} />
+        </InputFieldset>
+        <ButtonContainer>
+          <UpdateProfileButton disabled={isSettingsPatching} />
+        </ButtonContainer>
+      </Form>
+    </FormContainer>
+
+  );
+};
+
+export default SettingsForm;

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -10,6 +10,7 @@ import Comment from './comment';
 import CommentInput from './comment-input';
 import Modal from './modal';
 import Article from './article';
+import LoginForm from './forms/login-form';
 
 export {
   Author,
@@ -24,4 +25,5 @@ export {
   CommentInput,
   Modal,
   Article,
+  LoginForm,
 };


### PR DESCRIPTION
1. LoginForm, RegisterForm, SettingsForm вернулись.
2. В добавлении комментария styled.div -> styled.form, onClick -> onSubmit, скорректирована типизация компонента в связи с изменением пропсов.
3. Кнопкам входа, регистрации, публикации и обновления статьи, публикации комментария и обновления профиля дан тип 'submit' и удалён пропс onClick.
4. <CommentInput> сделан самодостаточным - управление перенесено внутрь компонента.
5. Редьюсер фида комментариев в слое view хранилища откорректирован, и соответственно рефакторены использующие его танки.
6. Убрано дублирующее поле ввода FieldNewPassword, использовавшая его форма SettingsForm отрефакторена.
7. Исправлены мелкие ошибки в текстовой области и инпутах, чуть поправлена типизация.